### PR TITLE
Fix setting wrong value for options.padding

### DIFF
--- a/src/js/components/layout/directions/horizontal.js
+++ b/src/js/components/layout/directions/horizontal.js
@@ -85,7 +85,10 @@ export default ( Splide, Components ) => {
 
 			this.gap = toPixel( root, options.gap );
 
-			const padding = options.padding;
+			const padding =
+				typeof options.padding === "object"
+					? { left: 0, right: 0, ...options.padding }
+					: options.padding;
 			const { left = padding, right = padding } = padding;
 
 			this.padding = {

--- a/src/js/components/layout/directions/vertical.js
+++ b/src/js/components/layout/directions/vertical.js
@@ -64,7 +64,10 @@ export default ( Splide, Components ) => {
 
 			this.gap = toPixel( root, options.gap );
 
-			const padding = options.padding;
+			const padding =
+				typeof options.padding === "object"
+					? { top: 0, bottom: 0, ...options.padding }
+					: options.padding;
 			const { top = padding, bottom = padding } = padding;
 
 			this.padding = {


### PR DESCRIPTION
If setting one of (left / right) or (top / bottom) to options.padding will got error or setting wrong value.
Because trying to set value from undefined property.

look at : https://jsfiddle.net/AmirHosseinKarimi/muoqLw9t/7/