### PR TITLE
Rewind option now scrolls to track edge or beginning before going over

### DIFF
--- a/src/js/components/controller/index.js
+++ b/src/js/components/controller/index.js
@@ -187,9 +187,11 @@ export default ( Splide, Components ) => {
 				}
 			} else {
 				if ( index > edge ) {
-					index = 0;
+					// If not at the edge yet, go to edge. Otherwise rewind to the start index.
+					index = Splide.index < edge ? edge : 0;
 				} else if ( index < 0 ) {
-					index = edge;
+					// If not at 0 yet, go to 0. Otherwise rewind to the edge index.
+					index = Splide.index > 0 ? 0 : edge;
 				}
 			}
 

--- a/tests/functionality/controller.test.js
+++ b/tests/functionality/controller.test.js
@@ -37,7 +37,17 @@ describe( 'The Controller', () => {
 
 		splide.options = { rewind: true };
 		expect( Controller.edgeIndex ).toBe( slides.length - perPage );
+		// Expect positive index to scroll to edge index if current index is below edge.
+		splide.index = 0;
+		expect( Controller.trim( 100 ) ).toBe( Controller.edgeIndex );
+		// Expect positive index to rewind to beginning if current index is at edge.
+		splide.index = Controller.edgeIndex;
 		expect( Controller.trim( 100 ) ).toBe( 0 );
+		// Expect negative index to scroll to beginning if index is above 0.
+		splide.index = Controller.edgeIndex;
+		expect( Controller.trim( -100 ) ).toBe( 0 );
+		// Expect negative index to rewind to edge if current index is 0.
+		splide.index = 0;
 		expect( Controller.trim( -100 ) ).toBe( Controller.edgeIndex );
 	} );
 

--- a/tests/functionality/rewind.test.js
+++ b/tests/functionality/rewind.test.js
@@ -12,10 +12,18 @@ describe( 'The "rewind" type Splide', () => {
 	} );
 
 	test( 'should rewind slider before the first slide or after the last(edgeIndex) slide.', () => {
+		// Expect scroll to end when current index is below edge.
+		splide.go( splide.length );
+		expect( splide.index ).toBe( splide.Components.Controller.edgeIndex );
+		// Expect rewind to beginning when current index is at edge.
 		splide.go( splide.length );
 		expect( splide.index ).toBe( 0 );
 
-		splide.go( '-' );
+		// Expect rewind to end when current index is at 0.
+		splide.go( -1 );
 		expect( splide.index ).toBe( splide.Components.Controller.edgeIndex );
+		// Expect scroll to beginning when current index is above 0.
+		splide.go( -splide.length );
+		expect( splide.index ).toBe( 0 );
 	} );
 } );


### PR DESCRIPTION
Changes `Controller` component behavior, so affects both arrows and
programmatic navigation.

This fixes an issue with sliders where `perMove` is
above 1 and the number of slides isn't divisible by `perMove`. In these
cases, rewind would skip showing slides as follows:
- In case of one whole page and one partial page, next arrow button did
nothing. Previous arrow button rewound to the edge correctly on the
first press but afterwards would not go back to start. In this case the next
arrow button would go the start.
- In case of multiple pages where the last one is partial, the last page
would be skipped when navigating using the next arrow button, and the first
page would be skipped when navigating using the previous arrow button.

The fix causes rewind to first go the edge if not yet at the edge for
positive indices, and to first go to the beginning if not yet at the
beginning for negative indices.

Note that this also changes the behavior of `rewind` for sliders where
`perMove` is 1 as indices above the edge or below zero will now go
to the edge or zero unless already there. I feel like this is more in
line with user expectations as it doesn't inadvertently skip slides,
but the change should probably be considered breaking.

If the change is too drastic, I suppose the same could be achieved
by changing the behavior of the `Arrows` component to take this into
account.