### PR TITLE
Bug Fix: pagination dot button broken when perPage option is float.

### DIFF
--- a/src/js/components/controller/index.js
+++ b/src/js/components/controller/index.js
@@ -115,7 +115,7 @@ export default ( Splide, Components ) => {
 			}
 
 			const length  = Splide.length;
-			const perPage = options.perPage;
+			const perPage = parseInt(options.perPage);
 
 			let index = page * perPage;
 			index = index - ( this.pageLength * perPage - length ) * floor( index / length );
@@ -141,7 +141,7 @@ export default ( Splide, Components ) => {
 			}
 
 			const length  = Splide.length;
-			const perPage = options.perPage;
+			const perPage = parseInt(options.perPage);
 
 			// Make the last "perPage" number of slides belong to the last page.
 			if ( length - perPage <= index && index < length ) {

--- a/src/js/components/pagination/index.js
+++ b/src/js/components/pagination/index.js
@@ -165,7 +165,7 @@ export default ( Splide, Components, name ) => {
 		const list     = create( 'ul', { class: classes.pagination } );
 
 		const items = Elements.getSlides( false )
-			.filter( Slide => options.focus !== false || Slide.index % options.perPage === 0 )
+			.filter( Slide => options.focus !== false || Slide.index % parseint(options.perPage) === 0 )
 			.map( ( Slide, page ) => {
 				const li     = create( 'li', {} );
 				const button = create( 'button', { class: classes.page, type: 'button' } );


### PR DESCRIPTION
Sometimes people want to show 2.5 or 3.3 as perPage, in that case however, the pagination shows only one dot and doesn't function properly.

Since the pagination expects options.perPage to be an integer, I add type cast
 in some case, so the number of dot and pagination will work fine evne with a float type options.perPage.
And the screen will still keep the float ratio not only integer.