### PR TITLE
Bug fix: Splider doesn't work on Safari, iOS v9 and lower.

### DIFF
--- a/src/js/utils/dom.js
+++ b/src/js/utils/dom.js
@@ -35,7 +35,7 @@ export function child( parent, tagOrClassName ) {
 }
 
 /**
- * Return chile elements that matches the provided tag or class name.
+ * Return child elements that matches the provided tag or class name.
  *
  * @param {Element} parent         - A parent element.
  * @param {string}  tagOrClassName - A tag or class name.
@@ -45,7 +45,7 @@ export function child( parent, tagOrClassName ) {
 export function children( parent, tagOrClassName ) {
 	if ( parent ) {
 		return values( parent.children ).filter( child => {
-			return hasClass( child, tagOrClassName.split( ' ' )[0] ) || child.tagName === tagOrClassName;
+			return (child instanceof Element) && (hasClass(child, tagOrClassName.split(' ')[0]) || child.tagName === tagOrClassName);
 		} );
 	}
 


### PR DESCRIPTION
Make sure the child array collection only contains elements in older browsers.