### PR TITLE
fix: #177 [BUG] mobile Safari stops emitting 'transitioned' in some cases

### DIFF
--- a/src/js/transitions/slide/index.js
+++ b/src/js/transitions/slide/index.js
@@ -71,6 +71,8 @@ export default ( Splide, Components ) => {
 				transition: `transform ${ speed }ms ${ options.easing }`,
 				transform : `translate(${ coord.x }px,${ coord.y }px)`,
 			} );
+			
+			setTimeout(done, speed)
 		},
 	};
 }


### PR DESCRIPTION
fixes #177