### PR TITLE
Fix: Check if window is actually present before registering it to window object

### DIFF
--- a/build/complete/complete.js
+++ b/build/complete/complete.js
@@ -19,4 +19,6 @@ export class Splide extends Core {
 }
 
 // Register the class as a global variable for non-ES6 environment.
-window.Splide = Splide;
+if (typeof window !== 'undefined') {
+	window.Splide = Splide;
+}


### PR DESCRIPTION
Had an slight issue with the package and initialising it on server side crashing at import as there is no check if the window is actually present.

Please take a look, there might be a better solution but this should fix it none the less :)  