### PR TITLE
fix last slide not being marked is-visible due to rounding

### DIFF
--- a/src/js/components/elements/slide.js
+++ b/src/js/components/elements/slide.js
@@ -169,7 +169,7 @@ export default ( Splide, index, realIndex, slide ) => {
 				return active;
 			}
 
-			const { ceil }  = Math;
+			const { ceil, floor }  = Math;
 			const trackRect = getRect( Splide.Components.Elements.track );
 			const slideRect = getRect( slide );
 
@@ -177,7 +177,7 @@ export default ( Splide, index, realIndex, slide ) => {
 				return trackRect.top <= slideRect.top && slideRect.bottom <= ceil( trackRect.bottom );
 			}
 
-			return trackRect.left <= slideRect.left && slideRect.right <= ceil( trackRect.right );
+			return trackRect.left <= slideRect.left && floor( slideRect.right ) <= ceil( trackRect.right );
 		},
 
 		/**


### PR DESCRIPTION
Hello! I am a user of Splide.js and love the library. Thank you so much for sharing it with us.

I have been running into a problem where the last slide in my carousel was not having the `is-visible` class applied to it, even though it was visible. I dug into the Splide code and saw where the problem was happening. The slide is not being marked `is-visible` at some browser widths due to the comparison between `slideRect.right` and `trackRect.right`. 

<img width="632" alt="Screen Shot 2021-02-22 at 4 59 12 PM" src="https://user-images.githubusercontent.com/8743121/108775674-6f879000-752f-11eb-8461-49b84eb03d53.png">

If we round `slideRect.right` down using `Math.floor`, the comparison will work as intended and the slide will be marked `is-visible`.