### PR TITLE
fix(278) changed some "window" references to "global" to allow for SS…

### DIFF
--- a/dist/js/splide.js
+++ b/dist/js/splide.js
@@ -2180,9 +2180,9 @@ var UID_NAME = 'uid';
    */
 
   if (!root.id) {
-    window.splide = window.splide || {};
-    var uid = window.splide[UID_NAME] || 0;
-    window.splide[UID_NAME] = ++uid;
+    global.splide = global.splide || {};
+    var uid = global.splide[UID_NAME] || 0;
+    global.splide[UID_NAME] = ++uid;
     root.id = "splide" + pad(uid);
   }
   /**
@@ -5854,6 +5854,6 @@ var complete_Splide = /*#__PURE__*/function (_Core) {
   return Splide;
 }(Splide); // Register the class as a global variable for non-ES6 environment.
 
-window.Splide = complete_Splide;
+global.Splide = complete_Splide;
 /******/ })()
 ;


### PR DESCRIPTION
This update fixes the following issue:
https://github.com/Splidejs/splide/issues/278

Since SSR rendering in Next.js (and others) doesn't have a window, Splide causes an error when building the project.
Changing the references to the window the are needed at render time to reference global fixes the issue.

I manually tested the update by creating various types of sliders in Next.js in Chrome Version 88.0.4324.150 (Official Build) (x86_64).