### PR TITLE
Bug fix: keyboard control should only be activated when splide is in focus

### DIFF
--- a/src/js/components/keyboard/index.js
+++ b/src/js/components/keyboard/index.js
@@ -78,7 +78,7 @@ export default ( Splide ) => {
 					}
 
 					Splide.on( 'keydown', e => {
-						if ( map[ e.key ] ) {
+						if ( root.contains( document.activeElement ) && map[ e.key ] ) {
 							Splide.go( map[ e.key ] );
 						}
 					}, target );


### PR DESCRIPTION
Example scenario: a user could be using `ArrowRight` keyboard when typing in a textarea. This interaction should not cause effects on the state of splide.