### PR TITLE
Bug Fix: fixed typings for typescript strict mode

### DIFF
--- a/src/js/splide.d.ts
+++ b/src/js/splide.d.ts
@@ -305,7 +305,7 @@ export interface EventObject {
 
 	emit( events: string, ...args: any ): void;
 
-	destroy();
+	destroy(): void;
 }
 
 /**
@@ -375,7 +375,7 @@ export interface EssentialComponentCollection {
  * Interface for collection of all components including extensions.
  */
 export interface ComponentCollection extends EssentialComponentCollection {
-	[ name: string ]: Component;
+	[ name: string ]: Component | undefined;
 }
 
 /**


### PR DESCRIPTION
Trying to use splide in Angular 12 gave me typing errors. Angular 12 uses strict mode by default.