### PR TITLE
Fixed error in minified code

### DIFF
--- a/src/js/components/Controller/Controller.ts
+++ b/src/js/components/Controller/Controller.ts
@@ -151,7 +151,7 @@ export function Controller( Splide: Splide, Components: Components, options: Opt
       const [ , indicator, number ] = control.match( /([+\-<>])(\d+)?/ ) || [];
 
       if ( indicator === '+' || indicator === '-' ) {
-        index = computeDestIndex( currIndex + (+`${ indicator }${ +number || 1 }`), currIndex, true );
+        index = computeDestIndex( currIndex + ( +`${ indicator }${ +number || 1 }` ), currIndex, true );
       } else if ( indicator === '>' ) {
         index = number ? toIndex( +number ) : getNext( true );
       } else if ( indicator === '<' ) {


### PR DESCRIPTION
Some minifiers could not correctly interpret this line of code (line 152 in Controller.ts file).

It would throw "Uncaught SyntaxError: missing ) after argument list" exception after being minified, so I added paranthesis around the expression to avoid this.