### PR TITLE
add types to main exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     ".": {
       "require": "./dist/js/splide.cjs.js",
       "import": "./dist/js/splide.esm.js",
-      "default": "./dist/js/splide.esm.js"
+      "default": "./dist/js/splide.esm.js",
+      "types": "./dist/types/index.d.ts"
     },
     "./src/js/utils": {
       "require": "./dist/js/utils/splide-utils.cjs.js",


### PR DESCRIPTION
<!--
  Please make sure to add a new issue before you send PR!
-->

## Related Issues

#1003 

## Description

This adds the `types` field to the main entrypoint defined in package.json `exports`

Ref: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing
