### PR TITLE
Bug that autoplay stops when a click or drag event occurs while autoplay is enabled. ( #117 )

### DIFF
--- a/src/js/components/Autoplay/Autoplay.ts
+++ b/src/js/components/Autoplay/Autoplay.ts
@@ -5,13 +5,14 @@ import {
   EVENT_AUTOPLAY_PLAY,
   EVENT_AUTOPLAY_PLAYING,
   EVENT_MOVE,
+  EVENT_MOVED,
   EVENT_REFRESH,
   EVENT_SCROLL,
 } from '../../constants/events';
 import { EventInterface, RequestInterval } from '../../constructors';
 import { Splide } from '../../core/Splide/Splide';
 import { BaseComponent, Components, Options } from '../../types';
-import { getAttribute, setAttribute, style, toggleClass } from '../../utils';
+import { apply, getAttribute, setAttribute, style, toggleClass } from '../../utils';
 import { INTERVAL_DATA_ATTRIBUTE } from './constants';
 
 
@@ -98,13 +99,15 @@ export function Autoplay( Splide: Splide, Components: Components, options: Optio
 
     on( [ EVENT_MOVE, EVENT_SCROLL, EVENT_REFRESH ], interval.rewind );
     on( EVENT_MOVE, onMove );
+    on( EVENT_MOVED, apply( play, false ) );
   }
 
   /**
    * Starts autoplay and clears all flags.
+   * @param isRestart - Determines whether to restart autoplay or not.
    */
-  function play(): void {
-    if ( isPaused() && Components.Slides.isEnough() ) {
+  function play(isRestart = true): void {
+    if ( ( isRestart && isPaused() && Components.Slides.isEnough() ) || ( ! isRestart && ! stopped && Components.Slides.isEnough() ) ) {
       interval.start( ! options.resetProgress );
       focused = hovered = stopped = false;
       update();


### PR DESCRIPTION
<!--
  Please make sure to add a new issue before you send PR!
-->

## Related Issues

#117

<!--
  Link to the issue
-->

## Description

日本のかたのようなのでせっかくなので日本語でPR出させていただきます。

素敵なライブラリありがとうございます :)
重宝させていただいております。
関連Issueの通りですが、自分の環境でも上記Issueの問題が依然として[doc](https://ja.splidejs.com/guides/autoplay/)でも確認できました。（下記動画）
なお、こちらの症状ですがカルーセル範囲外をクリックすることでautoplayが再開することも確認済みです。

https://user-images.githubusercontent.com/82146166/231458603-4cb184cd-fbfa-467b-a359-425d5b9b6e0c.mov

コード読む感じ、play関数の責務がPause状態からの復帰のようにも思えたので、別途関数を分けるような下記の修正のほうが好ましいのかもと思いつつ、これのためだけに関数1つ増やすのもどうなのかとも思ったので一旦この状態で出しておきます。

```diff
+ on( EVENT_MOVED, keepPlaying );
// ...
+ function keepPlaying(): void {
+ if (!sttoped) play()
+ }
```

<details>
<summary>English</summary>
Since you seem to be from Japan, I'll put up a PR in Japanese.

Thank you very much for your wonderful library :)
It is very useful.
I have been using it for a while now, but I still have the same problem as the above issue in my environment (see video below).
I have also confirmed that autoplay resumes by clicking outside the carousel area.

I read the code, and it seems that the responsibility of the play function is to recover from the pause state, so I thought it might be preferable to modify the code below to separate a separate function, but I also wondered if it would be a good idea to add a function just for this purpose, so I'll leave it as it is for now.
</details>

## test suites

```
# npm run jest

Test Suites: 102 passed, 102 total
Tests:       403 passed, 403 total
Snapshots:   0 total
Time:        32.782 s
Ran all test suites.
```

```
# lint

(base) % npm run eslint      

> @splidejs/splide@4.1.4 eslint
> eslint src

(base) %
```

余談ですが npm install時に forceオプション付けてしまいました
.node-versionファイルかpackage.jsonにengine指定があると嬉しいです（node version起因でなければすみません🙇‍♂️）

<!-- Write a brief description here -->
