### PR TITLE
Added union type: SliderType to options.type

### DIFF
--- a/src/js/core/Splide/Splide.ts
+++ b/src/js/core/Splide/Splide.ts
@@ -8,7 +8,7 @@ import { CREATED, DESTROYED, IDLE, STATES } from '../../constants/states';
 import { FADE } from '../../constants/types';
 import { EventInterface, EventInterfaceObject, State, StateObject } from '../../constructors';
 import { Fade, Slide } from '../../transitions';
-import { AnyFunction, ComponentConstructor, Components, EventMap, Options, SyncTarget } from '../../types';
+import { AnyFunction, ComponentConstructor, Components, EventMap, Options, SliderType, SyncTarget } from '../../types';
 import { addClass, assert, assign, empty, forOwn, getAttribute, isString, merge, query, slice } from '../../utils';
 import { ARIA_LABEL, ARIA_LABELLEDBY } from '../../constants/attributes';
 
@@ -323,7 +323,7 @@ export class Splide {
    *
    * @return `true` if the type matches the current one, or otherwise `false`.
    */
-  is( type: string ): boolean {
+  is( type: SliderType ): boolean {
     return this._o.type === type;
   }
 

--- a/src/js/types/general.ts
+++ b/src/js/types/general.ts
@@ -18,6 +18,13 @@ export type AnyFunction = ( ...args: any[] ) => any;
 export type ComponentConstructor = ( Splide: Splide, Components: Components, options: Options ) => BaseComponent;
 
 /**
+ * The type for a slider.
+ * 
+ * @since 4.1.5
+ */
+export type SliderType = 'slide' | 'loop' | 'fade';
+
+/**
  * The interface for any component.
  *
  * @since 3.0.0

--- a/src/js/types/options.ts
+++ b/src/js/types/options.ts
@@ -1,4 +1,5 @@
 import { I18N } from '../constants/i18n';
+import { SliderType } from './general';
 
 
 /**
@@ -13,7 +14,7 @@ export interface Options extends ResponsiveOptions {
    * - 'loop' : A carousel slider
    * - 'fade' : A slider with the fade transition. This does not support the perPage option.
    */
-  type?: string;
+  type?: SliderType;
 
   /**
    * The `role` attribute for the root element.


### PR DESCRIPTION
## Description

The `Options.type` field is of type string, so the user can set any string value, but the docs only mention three options: `slide`, `loop`, and `fade`. This PR adds a union type to allow only those options.



