### PR TITLE
fix(Move): round "translate" destination to prevent problems around images

### DIFF
--- a/src/js/components/Move/Move.ts
+++ b/src/js/components/Move/Move.ts
@@ -122,7 +122,7 @@ export function Move( Splide: Splide, Components: Components, options: Options )
   function translate( position: number, preventLoop?: boolean ): void {
     if ( ! Splide.is( FADE ) ) {
       const destination = preventLoop ? position : loop( position );
-      style( list, 'transform', `translate${ resolve( 'X' ) }(${ destination }px)` );
+      style( list, 'transform', `translate${ resolve( 'X' ) }(${ Math.round( destination ) }px)` );
       position !== destination && emit( EVENT_SHIFTED );
     }
   }


### PR DESCRIPTION
<!--
  Please make sure to add a new issue before you send PR!
-->

## Related Issues

fixes #1125 

<!--
  Link to the issue
-->

## Description

Move.translate() use to make track element translate into position with sub-pixel fragment (e.g. `translateY(-200.14px)`)

It causes browsers render image-like contents problematically; #1125 says "renders blurry", I found gaps between two adjacent image slides.

rounding the position will solve this problem.

<!-- Write a brief description here -->
