### PR TITLE
Added extra disabled check

### DIFF
--- a/src/js/components/Drag/Drag.ts
+++ b/src/js/components/Drag/Drag.ts
@@ -148,7 +148,7 @@ export function Drag( Splide: Splide, Components: Components, options: Options )
       emit( EVENT_DRAG );
     }
 
-    if ( e.cancelable ) {
+    if ( e.cancelable && ! disabled ) {
       if ( dragging ) {
         Move.translate( basePosition + constrain( diffCoord( e ) ) );
 
@@ -183,7 +183,7 @@ export function Drag( Splide: Splide, Components: Components, options: Options )
       emit( EVENT_DRAGGED );
     }
 
-    if ( dragging ) {
+    if ( dragging && ! disabled ) {
       move( e );
       prevent( e );
     }


### PR DESCRIPTION
#1350 

## Description

This PR adds an extra disabled check to the `onPointerUp` and `onPointerMove` methods in the Drag component of SplideJs. This change is necessary to improve the flexibility of combining SplideJs with other features, such as pinch zoom.

### Changes
- Added an extra disabled check to the `onPointerUp` method to prevent the event from being registered when the component is disabled.
- Added an extra disabled check to the `onPointerMove` method to prevent the slider from moving when the component is disabled.